### PR TITLE
Handle idle /localnodes refresh cadence

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,20 @@ cfg.node_health.quarantine_traffic_interval = 20;
 cfg.node_health.quarantine_success_threshold = 3;
 ```
 
+### Discovery Refresh
+
+`AlternatorLiveNodes::Start()` runs background `/localnodes` refreshes. Recent request activity uses
+`nodes_list_update_period`, while idle clients use `idle_nodes_list_update_period`:
+
+```cpp
+scylladb::alternator::Config cfg;
+cfg.nodes_list_update_period = std::chrono::seconds(1);
+cfg.idle_nodes_list_update_period = std::chrono::minutes(1);
+```
+
+The AWS helper starts and stops this background refresh automatically. The core `AlternatorLiveNodes`
+type leaves lifecycle control to the caller.
+
 The endpoint provider itself chooses nodes, but AWS SDK for C++ does not expose a public per-attempt hook equivalent to
 the Go SDK v2 middleware used by `alternator-client-golang`.
 
@@ -137,6 +151,7 @@ auto batch_plan = helper.NewBatchWriteQueryPlan({
 - `/localnodes` discovery with cluster, datacenter, and rack scopes.
 - Scope fallback chains such as rack -> datacenter -> cluster.
 - Cluster scope merge across seed nodes.
+- Active and idle `/localnodes` refresh cadence.
 - Active, quarantined, and down node pools with rigid observation-based transitions.
 - Round-robin `NextNode()` and flat per-request query plans, including Go-compatible seeded plans for affinity callers.
 - Key-route affinity helpers for single-write partition keys and batch-write preferred-node voting.

--- a/include/scylladb/alternator/aws/dynamodb_helper.h
+++ b/include/scylladb/alternator/aws/dynamodb_helper.h
@@ -94,6 +94,7 @@ public:
     DynamoDBHelper(std::vector<std::string> initial_nodes,
                    Config config = {},
                    std::shared_ptr<HttpClient> discovery_http_client = nullptr);
+    ~DynamoDBHelper();
 
     [[nodiscard]] std::shared_ptr<Aws::DynamoDB::DynamoDBClient> NewDynamoDB() const;
     [[nodiscard]] Aws::DynamoDB::DynamoDBClientConfiguration NewClientConfiguration() const;

--- a/include/scylladb/alternator/config.h
+++ b/include/scylladb/alternator/config.h
@@ -22,8 +22,8 @@ struct Config {
     std::string aws_region = "default-alb-region";
     Credentials credentials;
 
-    std::chrono::milliseconds nodes_list_update_period{std::chrono::minutes(5)};
-    std::chrono::milliseconds idle_nodes_list_update_period{std::chrono::hours(2)};
+    std::chrono::milliseconds nodes_list_update_period{std::chrono::seconds(1)};
+    std::chrono::milliseconds idle_nodes_list_update_period{std::chrono::minutes(1)};
     std::chrono::milliseconds http_client_timeout{0};
     std::chrono::milliseconds connect_timeout{1000};
 

--- a/include/scylladb/alternator/live_nodes.h
+++ b/include/scylladb/alternator/live_nodes.h
@@ -55,7 +55,9 @@ private:
     [[nodiscard]] Url NextQuarantinedNode() const;
     [[nodiscard]] Url StickyQuarantinedNodeForHash(std::int64_t hash, const std::vector<Url>& active_nodes) const;
     void RemoveQuarantineHashAssignmentsForNode(const Url& node);
-    void MaybeRefresh();
+    void MarkActivity();
+    [[nodiscard]] std::chrono::milliseconds RefreshIntervalForNow(std::chrono::steady_clock::time_point now) const;
+    void ScheduleNextRefresh(std::chrono::steady_clock::time_point now);
     void BackgroundLoop();
 
     Config config_;
@@ -70,6 +72,7 @@ private:
     mutable std::atomic<std::uint64_t> quarantine_plan_index_{0};
     mutable std::atomic<std::uint64_t> quarantine_node_index_{0};
     std::chrono::steady_clock::time_point next_update_;
+    std::chrono::steady_clock::time_point last_activity_;
 
     std::mutex background_mutex_;
     std::condition_variable background_cv_;

--- a/src/aws_dynamodb_helper.cpp
+++ b/src/aws_dynamodb_helper.cpp
@@ -296,7 +296,13 @@ DynamoDBHelper::DynamoDBHelper(std::vector<std::string> initial_nodes,
                                                    config,
                                                    std::move(discovery_http_client)))
     , config_(std::move(config))
-    , partition_keys_(config_.key_route_affinity.partition_key_by_table) {}
+    , partition_keys_(config_.key_route_affinity.partition_key_by_table) {
+    nodes_->Start();
+}
+
+DynamoDBHelper::~DynamoDBHelper() {
+    Stop();
+}
 
 std::shared_ptr<Aws::DynamoDB::DynamoDBClient> DynamoDBHelper::NewDynamoDB() const {
     auto client_config = NewClientConfiguration();

--- a/src/live_nodes.cpp
+++ b/src/live_nodes.cpp
@@ -160,7 +160,13 @@ AlternatorLiveNodes::AlternatorLiveNodes(std::vector<std::string> initial_nodes,
     initial_nodes_ = SortAndDedupeNodes(std::move(initial_nodes_));
     live_nodes_ = initial_nodes_;
     health_store_ = std::make_unique<NodeHealthStore>(config_.node_health, initial_nodes_);
-    next_update_ = std::chrono::steady_clock::now() + config_.nodes_list_update_period;
+    const auto now = std::chrono::steady_clock::now();
+    last_activity_ = std::chrono::steady_clock::time_point::min();
+    if (config_.idle_nodes_list_update_period > std::chrono::milliseconds::zero()) {
+        next_update_ = now + config_.idle_nodes_list_update_period;
+    } else {
+        next_update_ = std::chrono::steady_clock::time_point::max();
+    }
 }
 
 AlternatorLiveNodes::~AlternatorLiveNodes() {
@@ -168,7 +174,7 @@ AlternatorLiveNodes::~AlternatorLiveNodes() {
 }
 
 Url AlternatorLiveNodes::NextNode() {
-    MaybeRefresh();
+    MarkActivity();
 
     auto candidates = GetActiveNodes();
     if (candidates.empty()) {
@@ -289,6 +295,7 @@ void AlternatorLiveNodes::Stop() {
 }
 
 void AlternatorLiveNodes::ReportNodeResult(const Url& node, NodeHealthObservation observation) {
+    MarkActivity();
     health_store_->ReportNodeResult(node, observation);
     auto status = health_store_->GetNodeStatus(node);
     if (!status || status->state != NodeHealthState::Quarantined) {
@@ -501,59 +508,96 @@ void AlternatorLiveNodes::RemoveQuarantineHashAssignmentsForNode(const Url& node
     }
 }
 
-void AlternatorLiveNodes::MaybeRefresh() {
-    if (config_.nodes_list_update_period <= std::chrono::milliseconds::zero()) {
-        return;
-    }
-
+void AlternatorLiveNodes::MarkActivity() {
     const auto now = std::chrono::steady_clock::now();
-    bool should_update = false;
+    bool notify = false;
     {
         std::lock_guard<std::mutex> lock(mutex_);
-        if (now >= next_update_) {
-            next_update_ = now + config_.nodes_list_update_period;
-            should_update = true;
+        last_activity_ = now;
+        if (config_.nodes_list_update_period > std::chrono::milliseconds::zero()) {
+            const auto active_due = now + config_.nodes_list_update_period;
+            if (next_update_ > active_due) {
+                next_update_ = active_due;
+                notify = true;
+            } else if (now >= next_update_) {
+                notify = true;
+            }
         }
     }
-    if (should_update) {
-        try {
-            UpdateLiveNodes();
-        } catch (...) {
-            // Keep current node list when refresh fails.
-        }
+    if (notify) {
+        background_cv_.notify_all();
     }
+}
+
+std::chrono::milliseconds AlternatorLiveNodes::RefreshIntervalForNow(
+    std::chrono::steady_clock::time_point now) const {
+    const bool has_activity = last_activity_ != std::chrono::steady_clock::time_point::min();
+    const bool active_enabled = config_.nodes_list_update_period > std::chrono::milliseconds::zero();
+    const bool idle_enabled = config_.idle_nodes_list_update_period > std::chrono::milliseconds::zero();
+    const bool recently_active =
+        has_activity &&
+        (!idle_enabled || now - last_activity_ < config_.idle_nodes_list_update_period);
+
+    if (recently_active && active_enabled) {
+        return config_.nodes_list_update_period;
+    }
+    if (idle_enabled) {
+        return config_.idle_nodes_list_update_period;
+    }
+    return std::chrono::milliseconds::zero();
+}
+
+void AlternatorLiveNodes::ScheduleNextRefresh(std::chrono::steady_clock::time_point now) {
+    const auto interval = RefreshIntervalForNow(now);
+    if (interval <= std::chrono::milliseconds::zero()) {
+        next_update_ = std::chrono::steady_clock::time_point::max();
+        return;
+    }
+    next_update_ = now + interval;
 }
 
 void AlternatorLiveNodes::BackgroundLoop() {
     std::unique_lock<std::mutex> lock(background_mutex_);
-    const auto idle_period = config_.idle_nodes_list_update_period;
     const auto probe_period = config_.node_health.down_node_probe_period;
-    auto next_idle_update = std::chrono::steady_clock::now() + idle_period;
     auto next_down_probe = std::chrono::steady_clock::now() + probe_period;
 
     while (!stopping_) {
-        const bool idle_enabled = idle_period > std::chrono::milliseconds::zero();
         const bool probe_enabled = probe_period > std::chrono::milliseconds::zero();
-        if (!idle_enabled && !probe_enabled) {
+        std::chrono::steady_clock::time_point next_update;
+        {
+            std::lock_guard<std::mutex> state_lock(mutex_);
+            next_update = next_update_;
+        }
+        const bool refresh_enabled = next_update != std::chrono::steady_clock::time_point::max();
+
+        if (!refresh_enabled && !probe_enabled) {
             background_cv_.wait(lock, [this] { return stopping_; });
             continue;
         }
 
-        auto wake_at = idle_enabled ? next_idle_update : next_down_probe;
-        if (probe_enabled && (!idle_enabled || next_down_probe < wake_at)) {
+        auto wake_at = refresh_enabled ? next_update : next_down_probe;
+        if (probe_enabled && (!refresh_enabled || next_down_probe < wake_at)) {
             wake_at = next_down_probe;
         }
 
-        if (background_cv_.wait_until(lock, wake_at, [this] { return stopping_; })) {
+        const auto wait_result = background_cv_.wait_until(lock, wake_at);
+        if (stopping_) {
+            continue;
+        }
+        if (wait_result == std::cv_status::no_timeout) {
             continue;
         }
 
         const auto now = std::chrono::steady_clock::now();
-        const bool should_update = idle_enabled && now >= next_idle_update;
-        const bool should_probe_down = probe_enabled && now >= next_down_probe;
-        if (should_update) {
-            next_idle_update = now + idle_period;
+        bool should_update = false;
+        {
+            std::lock_guard<std::mutex> state_lock(mutex_);
+            should_update = next_update_ != std::chrono::steady_clock::time_point::max() && now >= next_update_;
+            if (should_update) {
+                ScheduleNextRefresh(now);
+            }
         }
+        const bool should_probe_down = probe_enabled && now >= next_down_probe;
         if (should_probe_down) {
             next_down_probe = now + probe_period;
         }

--- a/tests/live_nodes_test.cpp
+++ b/tests/live_nodes_test.cpp
@@ -368,3 +368,32 @@ TEST(AlternatorLiveNodes, BackgroundProbesDownNodesPeriodically) {
     EXPECT_GT(probes.load(), 0);
     EXPECT_EQ(nodes.GetQuarantinedNodes(), std::vector<Url>({recovering}));
 }
+
+TEST(AlternatorLiveNodes, BackgroundRefreshUsesActivePeriodOnlyAfterActivity) {
+    Config cfg;
+    cfg.nodes_list_update_period = std::chrono::milliseconds{10};
+    cfg.idle_nodes_list_update_period = std::chrono::hours{1};
+    cfg.node_health.down_node_probe_period = std::chrono::milliseconds{0};
+
+    std::atomic<int> requests{0};
+    auto http = std::make_shared<FakeHttpClient>([&](const Url& url) {
+        EXPECT_EQ(url.path, "/localnodes");
+        ++requests;
+        return HttpResponse{200, "[\"node2.local\"]"};
+    });
+
+    AlternatorLiveNodes nodes({"node1.local"}, cfg, http);
+    nodes.Start();
+    std::this_thread::sleep_for(std::chrono::milliseconds{30});
+    EXPECT_EQ(requests.load(), 0);
+    EXPECT_EQ(Hosts(nodes.GetNodes()), std::vector<std::string>({"node1.local"}));
+
+    EXPECT_EQ(nodes.NextNode().host, "node1.local");
+    for (int i = 0; i < 50 && requests.load() == 0; ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds{10});
+    }
+    nodes.Stop();
+
+    EXPECT_GT(requests.load(), 0);
+    EXPECT_EQ(Hosts(nodes.GetNodes()), std::vector<std::string>({"node2.local"}));
+}


### PR DESCRIPTION
## Summary
- use separate active and idle live-node refresh intervals
- schedule background refreshes from recent request activity instead of refreshing synchronously in `NextNode()`
- start and stop background live-node refresh automatically from the DynamoDB helper
- document the refresh cadence and add a focused idle-to-active refresh test

## Testing
- `make check`
- `make test-unit`

Fixes #10