### PR TITLE
Reuse /localnodes discovery HTTP connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,18 @@ cfg.idle_nodes_list_update_period = std::chrono::minutes(1);
 The AWS helper starts and stops this background refresh automatically. The core `AlternatorLiveNodes`
 type leaves lifecycle control to the caller.
 
+When libcurl is available, the default discovery client reuses HTTP connections by default. It keeps
+a libcurl connection cache bounded by `max_connections` and can be disabled for debugging or
+compatibility:
+
+```cpp
+scylladb::alternator::Config cfg;
+cfg.max_connections = 100;
+cfg.reuse_discovery_connections = false;
+```
+
+The POSIX fallback discovery client supports plain HTTP only and closes each request.
+
 The endpoint provider itself chooses nodes, but AWS SDK for C++ does not expose a public per-attempt hook equivalent to
 the Go SDK v2 middleware used by `alternator-client-golang`.
 
@@ -152,6 +164,7 @@ auto batch_plan = helper.NewBatchWriteQueryPlan({
 - Scope fallback chains such as rack -> datacenter -> cluster.
 - Cluster scope merge across seed nodes.
 - Active and idle `/localnodes` refresh cadence.
+- Reused libcurl discovery HTTP connections with an opt-out switch.
 - Active, quarantined, and down node pools with rigid observation-based transitions.
 - Round-robin `NextNode()` and flat per-request query plans, including Go-compatible seeded plans for affinity callers.
 - Key-route affinity helpers for single-write partition keys and batch-write preferred-node voting.

--- a/include/scylladb/alternator/config.h
+++ b/include/scylladb/alternator/config.h
@@ -33,6 +33,7 @@ struct Config {
     std::string client_private_key_file;
 
     unsigned max_connections = 100;
+    bool reuse_discovery_connections = true;
     std::string user_agent = "scylladb-alternator-client-cpp/devel";
 
     NodeHealthStoreConfig node_health;

--- a/include/scylladb/alternator/http_client.h
+++ b/include/scylladb/alternator/http_client.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <mutex>
 #include <string>
 
 #include <scylladb/alternator/config.h>
@@ -23,11 +24,14 @@ public:
 class CurlHttpClient final : public HttpClient {
 public:
     explicit CurlHttpClient(Config config);
+    ~CurlHttpClient() override;
 
     [[nodiscard]] HttpResponse Get(const Url& url) const override;
 
 private:
     Config config_;
+    mutable std::mutex mutex_;
+    mutable void* reusable_handle_ = nullptr;
 };
 
 std::shared_ptr<HttpClient> NewDefaultHttpClient(const Config& config);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -14,6 +14,9 @@ void ValidateConfig(const Config& config) {
     if (!config.routing_scope) {
         throw std::invalid_argument("routing_scope must not be null");
     }
+    if (config.max_connections == 0) {
+        throw std::invalid_argument("max_connections must be > 0");
+    }
 }
 
 } // namespace scylladb::alternator

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -42,6 +42,66 @@ void SetDuration(CURL* curl, CURLoption option, std::chrono::milliseconds value)
     }
 }
 
+void ConfigureCurlForGet(CURL* curl, const Url& url, const Config& config, std::string& body) {
+    curl_easy_reset(curl);
+
+    const auto url_string = url.ToString();
+    curl_easy_setopt(curl, CURLOPT_URL, url_string.c_str());
+    curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
+    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &WriteBody);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &body);
+    curl_easy_setopt(curl, CURLOPT_TCP_KEEPALIVE, 1L);
+    curl_easy_setopt(curl, CURLOPT_MAXCONNECTS, static_cast<long>(config.max_connections));
+    curl_easy_setopt(curl, CURLOPT_FORBID_REUSE, config.reuse_discovery_connections ? 0L : 1L);
+    curl_easy_setopt(curl, CURLOPT_FRESH_CONNECT, config.reuse_discovery_connections ? 0L : 1L);
+
+    SetDuration(curl, CURLOPT_TIMEOUT_MS, config.http_client_timeout);
+    SetDuration(curl, CURLOPT_CONNECTTIMEOUT_MS, config.connect_timeout);
+
+    if (!config.user_agent.empty()) {
+        curl_easy_setopt(curl, CURLOPT_USERAGENT, config.user_agent.c_str());
+    }
+
+    if (!config.verify_ssl) {
+        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
+        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
+    }
+    if (!config.ca_file.empty()) {
+        curl_easy_setopt(curl, CURLOPT_CAINFO, config.ca_file.c_str());
+    }
+    if (!config.client_certificate_file.empty()) {
+        curl_easy_setopt(curl, CURLOPT_SSLCERT, config.client_certificate_file.c_str());
+    }
+    if (!config.client_private_key_file.empty()) {
+        curl_easy_setopt(curl, CURLOPT_SSLKEY, config.client_private_key_file.c_str());
+    }
+}
+
+HttpResponse PerformCurlGet(CURL* curl, const Url& url, const Config& config) {
+    std::string body;
+    ConfigureCurlForGet(curl, url, config, body);
+
+    curl_slist* headers = nullptr;
+    headers = curl_slist_append(
+        headers,
+        config.reuse_discovery_connections ? "Connection: keep-alive" : "Connection: close");
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+
+    const auto code = curl_easy_perform(curl);
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, nullptr);
+    if (headers != nullptr) {
+        curl_slist_free_all(headers);
+    }
+    if (code != CURLE_OK) {
+        throw std::runtime_error(curl_easy_strerror(code));
+    }
+
+    long status_code = 0;
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &status_code);
+    return HttpResponse{status_code, std::move(body)};
+}
+
 } // namespace
 
 CurlHttpClient::CurlHttpClient(Config config)
@@ -49,53 +109,34 @@ CurlHttpClient::CurlHttpClient(Config config)
     EnsureCurlInitialized();
 }
 
+CurlHttpClient::~CurlHttpClient() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (reusable_handle_ != nullptr) {
+        curl_easy_cleanup(static_cast<CURL*>(reusable_handle_));
+        reusable_handle_ = nullptr;
+    }
+}
+
 HttpResponse CurlHttpClient::Get(const Url& url) const {
     EnsureCurlInitialized();
+
+    if (config_.reuse_discovery_connections) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (reusable_handle_ == nullptr) {
+            reusable_handle_ = curl_easy_init();
+            if (reusable_handle_ == nullptr) {
+                throw std::runtime_error("curl_easy_init failed");
+            }
+        }
+        return PerformCurlGet(static_cast<CURL*>(reusable_handle_), url, config_);
+    }
 
     CURL* raw = curl_easy_init();
     if (raw == nullptr) {
         throw std::runtime_error("curl_easy_init failed");
     }
     std::unique_ptr<CURL, decltype(&curl_easy_cleanup)> curl(raw, &curl_easy_cleanup);
-
-    std::string body;
-    const auto url_string = url.ToString();
-    curl_easy_setopt(curl.get(), CURLOPT_URL, url_string.c_str());
-    curl_easy_setopt(curl.get(), CURLOPT_HTTPGET, 1L);
-    curl_easy_setopt(curl.get(), CURLOPT_NOSIGNAL, 1L);
-    curl_easy_setopt(curl.get(), CURLOPT_WRITEFUNCTION, &WriteBody);
-    curl_easy_setopt(curl.get(), CURLOPT_WRITEDATA, &body);
-    curl_easy_setopt(curl.get(), CURLOPT_TCP_KEEPALIVE, 1L);
-
-    SetDuration(curl.get(), CURLOPT_TIMEOUT_MS, config_.http_client_timeout);
-    SetDuration(curl.get(), CURLOPT_CONNECTTIMEOUT_MS, config_.connect_timeout);
-
-    if (!config_.user_agent.empty()) {
-        curl_easy_setopt(curl.get(), CURLOPT_USERAGENT, config_.user_agent.c_str());
-    }
-
-    if (!config_.verify_ssl) {
-        curl_easy_setopt(curl.get(), CURLOPT_SSL_VERIFYPEER, 0L);
-        curl_easy_setopt(curl.get(), CURLOPT_SSL_VERIFYHOST, 0L);
-    }
-    if (!config_.ca_file.empty()) {
-        curl_easy_setopt(curl.get(), CURLOPT_CAINFO, config_.ca_file.c_str());
-    }
-    if (!config_.client_certificate_file.empty()) {
-        curl_easy_setopt(curl.get(), CURLOPT_SSLCERT, config_.client_certificate_file.c_str());
-    }
-    if (!config_.client_private_key_file.empty()) {
-        curl_easy_setopt(curl.get(), CURLOPT_SSLKEY, config_.client_private_key_file.c_str());
-    }
-
-    const auto code = curl_easy_perform(curl.get());
-    if (code != CURLE_OK) {
-        throw std::runtime_error(curl_easy_strerror(code));
-    }
-
-    long status_code = 0;
-    curl_easy_getinfo(curl.get(), CURLINFO_RESPONSE_CODE, &status_code);
-    return HttpResponse{status_code, std::move(body)};
+    return PerformCurlGet(curl.get(), url, config_);
 }
 
 #else
@@ -221,6 +262,8 @@ HttpResponse ParseHttpResponse(const std::string& raw) {
 
 CurlHttpClient::CurlHttpClient(Config config)
     : config_(std::move(config)) {}
+
+CurlHttpClient::~CurlHttpClient() = default;
 
 HttpResponse CurlHttpClient::Get(const Url& url) const {
     if (url.scheme != "http") {

--- a/tests/http_client_test.cpp
+++ b/tests/http_client_test.cpp
@@ -9,8 +9,11 @@
 
 #include <atomic>
 #include <cstring>
+#include <sstream>
 #include <stdexcept>
+#include <string>
 #include <thread>
+#include <vector>
 
 using namespace scylladb::alternator;
 
@@ -91,6 +94,121 @@ private:
     std::thread worker_;
 };
 
+class CountingHttpServer {
+public:
+    CountingHttpServer(int expected_requests, bool keep_alive)
+        : expected_requests_(expected_requests)
+        , keep_alive_(keep_alive) {
+        fd_ = socket(AF_INET, SOCK_STREAM, 0);
+        if (fd_ < 0) {
+            throw std::runtime_error("socket failed");
+        }
+
+        int yes = 1;
+        setsockopt(fd_, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
+
+        sockaddr_in addr{};
+        addr.sin_family = AF_INET;
+        addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+        addr.sin_port = 0;
+        if (bind(fd_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
+            throw std::runtime_error("bind failed");
+        }
+        if (listen(fd_, expected_requests_) != 0) {
+            throw std::runtime_error("listen failed");
+        }
+
+        socklen_t len = sizeof(addr);
+        if (getsockname(fd_, reinterpret_cast<sockaddr*>(&addr), &len) != 0) {
+            throw std::runtime_error("getsockname failed");
+        }
+        port_ = ntohs(addr.sin_port);
+
+        worker_ = std::thread([this] {
+            while (request_count_.load() < expected_requests_) {
+                int client = accept(fd_, nullptr, nullptr);
+                if (client < 0) {
+                    return;
+                }
+                ++accept_count_;
+
+                while (request_count_.load() < expected_requests_) {
+                    auto request = ReadRequest(client);
+                    if (request.empty()) {
+                        break;
+                    }
+                    requests_.push_back(std::move(request));
+                    ++request_count_;
+
+                    const std::string body = "[\"node1.local\"]";
+                    const bool keep_connection =
+                        keep_alive_ && request_count_.load() < expected_requests_;
+                    std::ostringstream response;
+                    response << "HTTP/1.1 200 OK\r\n"
+                             << "Content-Length: " << body.size() << "\r\n"
+                             << "Connection: " << (keep_connection ? "keep-alive" : "close") << "\r\n"
+                             << "\r\n"
+                             << body;
+                    const auto response_text = response.str();
+                    send(client, response_text.data(), response_text.size(), 0);
+                    if (!keep_connection) {
+                        break;
+                    }
+                }
+                close(client);
+            }
+        });
+    }
+
+    ~CountingHttpServer() {
+        if (fd_ >= 0) {
+            close(fd_);
+        }
+        Wait();
+    }
+
+    void Wait() {
+        if (worker_.joinable()) {
+            worker_.join();
+        }
+    }
+
+    [[nodiscard]] std::uint16_t Port() const {
+        return port_;
+    }
+
+    [[nodiscard]] int AcceptCount() const {
+        return accept_count_.load();
+    }
+
+    [[nodiscard]] const std::vector<std::string>& Requests() const {
+        return requests_;
+    }
+
+private:
+    static std::string ReadRequest(int client) {
+        std::string request;
+        char buffer[1024];
+        while (request.find("\r\n\r\n") == std::string::npos) {
+            const auto n = recv(client, buffer, sizeof(buffer), 0);
+            if (n <= 0) {
+                return {};
+            }
+            request.append(buffer, static_cast<std::size_t>(n));
+        }
+        return request;
+    }
+
+    int fd_ = -1;
+    int expected_requests_ = 0;
+    bool keep_alive_ = false;
+    std::uint16_t port_ = 0;
+    std::atomic<int> accept_count_{0};
+    std::atomic<int> request_count_{0};
+    std::vector<std::string> requests_;
+    std::thread worker_;
+};
+
 } // namespace
 
 TEST(HttpClient, PerformsPlainHttpGet) {
@@ -105,4 +223,46 @@ TEST(HttpClient, PerformsPlainHttpGet) {
     EXPECT_EQ(response.status_code, 200);
     EXPECT_EQ(response.body, "[\"node1.local\"]");
     EXPECT_NE(server.Request().find("GET /localnodes?dc=dc1 HTTP/1.1"), std::string::npos);
+}
+
+TEST(HttpClient, ReusesDiscoveryConnectionByDefaultWithCurl) {
+#if SCYLLADB_ALTERNATOR_CLIENT_CPP_HAS_CURL
+    CountingHttpServer server(2, true);
+
+    Config cfg;
+    cfg.scheme = "http";
+    cfg.reuse_discovery_connections = true;
+    CurlHttpClient client(cfg);
+    const auto url = Url("http", "127.0.0.1", server.Port()).WithPathAndQuery("/localnodes");
+
+    EXPECT_EQ(client.Get(url).status_code, 200);
+    EXPECT_EQ(client.Get(url).status_code, 200);
+    server.Wait();
+
+    EXPECT_EQ(server.Requests().size(), 2U);
+    EXPECT_EQ(server.AcceptCount(), 1);
+#else
+    GTEST_SKIP() << "libcurl support is not enabled";
+#endif
+}
+
+TEST(HttpClient, CanDisableDiscoveryConnectionReuseWithCurl) {
+#if SCYLLADB_ALTERNATOR_CLIENT_CPP_HAS_CURL
+    CountingHttpServer server(2, false);
+
+    Config cfg;
+    cfg.scheme = "http";
+    cfg.reuse_discovery_connections = false;
+    CurlHttpClient client(cfg);
+    const auto url = Url("http", "127.0.0.1", server.Port()).WithPathAndQuery("/localnodes");
+
+    EXPECT_EQ(client.Get(url).status_code, 200);
+    EXPECT_EQ(client.Get(url).status_code, 200);
+    server.Wait();
+
+    EXPECT_EQ(server.Requests().size(), 2U);
+    EXPECT_EQ(server.AcceptCount(), 2);
+#else
+    GTEST_SKIP() << "libcurl support is not enabled";
+#endif
 }


### PR DESCRIPTION
## Summary
- reuse a persistent libcurl easy handle for `/localnodes` discovery by default
- send keep-alive for discovery requests and keep an opt-out switch for compatibility
- bound the libcurl connection cache with `max_connections` and validate that it is positive
- document discovery connection reuse and add tests that verify default reuse and opt-out behavior

## Testing
- `make check`
- `make test-unit`

Fixes #13