### PR TITLE
Configure TLS session caching for discovery

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ option(ALTERNATOR_CLIENT_CPP_BUILD_TESTS "Build unit tests" ON)
 option(ALTERNATOR_CLIENT_CPP_ENABLE_AWS "Build AWS SDK for C++ DynamoDB adapter when AWSSDK is available" ON)
 
 find_package(CURL QUIET)
+find_package(OpenSSL QUIET)
 find_package(Threads REQUIRED)
 
 add_library(alternator_client_cpp
@@ -41,6 +42,10 @@ target_link_libraries(alternator_client_cpp
 if(CURL_FOUND)
     target_link_libraries(alternator_client_cpp PUBLIC CURL::libcurl)
     target_compile_definitions(alternator_client_cpp PUBLIC SCYLLADB_ALTERNATOR_CLIENT_CPP_HAS_CURL=1)
+    if(OpenSSL_FOUND)
+        target_link_libraries(alternator_client_cpp PUBLIC OpenSSL::SSL)
+        target_compile_definitions(alternator_client_cpp PUBLIC SCYLLADB_ALTERNATOR_CLIENT_CPP_HAS_OPENSSL=1)
+    endif()
 else()
     message(STATUS "libcurl development package not found; default discovery client supports plain HTTP only")
 endif()

--- a/README.md
+++ b/README.md
@@ -118,6 +118,16 @@ cfg.reuse_discovery_connections = false;
 
 The POSIX fallback discovery client supports plain HTTP only and closes each request.
 
+TLS session caching is enabled by default for HTTPS discovery. The libcurl session cache can be
+disabled, and OpenSSL-backed libcurl builds also honor the configured cache size and timeout:
+
+```cpp
+scylladb::alternator::Config cfg;
+cfg.tls_session_cache_enabled = true;
+cfg.tls_session_cache_size = 1024;
+cfg.tls_session_timeout = std::chrono::hours(24);
+```
+
 The endpoint provider itself chooses nodes, but AWS SDK for C++ does not expose a public per-attempt hook equivalent to
 the Go SDK v2 middleware used by `alternator-client-golang`.
 
@@ -165,6 +175,7 @@ auto batch_plan = helper.NewBatchWriteQueryPlan({
 - Cluster scope merge across seed nodes.
 - Active and idle `/localnodes` refresh cadence.
 - Reused libcurl discovery HTTP connections with an opt-out switch.
+- TLS session cache enable/disable, cache size, and timeout configuration for HTTPS discovery.
 - Active, quarantined, and down node pools with rigid observation-based transitions.
 - Round-robin `NextNode()` and flat per-request query plans, including Go-compatible seeded plans for affinity callers.
 - Key-route affinity helpers for single-write partition keys and batch-write preferred-node voting.

--- a/cmake/scylladb-alternator-client-cpp-config.cmake.in
+++ b/cmake/scylladb-alternator-client-cpp-config.cmake.in
@@ -8,6 +8,10 @@ if(@CURL_FOUND@)
     find_dependency(CURL)
 endif()
 
+if(@OpenSSL_FOUND@)
+    find_dependency(OpenSSL)
+endif()
+
 if(@ALTERNATOR_CLIENT_CPP_AWS_TARGET_BUILT@)
     find_dependency(ZLIB)
     find_dependency(AWSSDK COMPONENTS dynamodb)

--- a/include/scylladb/alternator/config.h
+++ b/include/scylladb/alternator/config.h
@@ -31,6 +31,9 @@ struct Config {
     std::string ca_file;
     std::string client_certificate_file;
     std::string client_private_key_file;
+    bool tls_session_cache_enabled = true;
+    std::uint32_t tls_session_cache_size = 1024;
+    std::chrono::seconds tls_session_timeout{86400};
 
     unsigned max_connections = 100;
     bool reuse_discovery_connections = true;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -17,6 +17,14 @@ void ValidateConfig(const Config& config) {
     if (config.max_connections == 0) {
         throw std::invalid_argument("max_connections must be > 0");
     }
+    if (config.tls_session_cache_enabled) {
+        if (config.tls_session_cache_size == 0) {
+            throw std::invalid_argument("tls_session_cache_size must be > 0 when TLS session cache is enabled");
+        }
+        if (config.tls_session_timeout <= std::chrono::seconds::zero()) {
+            throw std::invalid_argument("tls_session_timeout must be > 0 when TLS session cache is enabled");
+        }
+    }
 }
 
 } // namespace scylladb::alternator

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -2,6 +2,9 @@
 
 #if SCYLLADB_ALTERNATOR_CLIENT_CPP_HAS_CURL
 #include <curl/curl.h>
+#if SCYLLADB_ALTERNATOR_CLIENT_CPP_HAS_OPENSSL
+#include <openssl/ssl.h>
+#endif
 #else
 #include <netdb.h>
 #include <sys/socket.h>
@@ -42,6 +45,37 @@ void SetDuration(CURL* curl, CURLoption option, std::chrono::milliseconds value)
     }
 }
 
+bool CurlUsesOpenSslBackend() {
+    const auto* info = curl_version_info(CURLVERSION_NOW);
+    if (info == nullptr || info->ssl_version == nullptr) {
+        return false;
+    }
+    const std::string ssl_version = info->ssl_version;
+    return ssl_version.find("OpenSSL") != std::string::npos ||
+           ssl_version.find("LibreSSL") != std::string::npos ||
+           ssl_version.find("BoringSSL") != std::string::npos;
+}
+
+#if SCYLLADB_ALTERNATOR_CLIENT_CPP_HAS_OPENSSL
+CURLcode ConfigureSslContext(CURL*, void* ssl_context, void* userdata) {
+    const auto* config = static_cast<const Config*>(userdata);
+    if (config == nullptr || ssl_context == nullptr) {
+        return CURLE_OK;
+    }
+
+    auto* ctx = static_cast<SSL_CTX*>(ssl_context);
+    if (!config->tls_session_cache_enabled) {
+        SSL_CTX_set_session_cache_mode(ctx, SSL_SESS_CACHE_OFF);
+        return CURLE_OK;
+    }
+
+    SSL_CTX_set_session_cache_mode(ctx, SSL_SESS_CACHE_CLIENT);
+    SSL_CTX_sess_set_cache_size(ctx, static_cast<long>(config->tls_session_cache_size));
+    SSL_CTX_set_timeout(ctx, static_cast<long>(config->tls_session_timeout.count()));
+    return CURLE_OK;
+}
+#endif
+
 void ConfigureCurlForGet(CURL* curl, const Url& url, const Config& config, std::string& body) {
     curl_easy_reset(curl);
 
@@ -52,6 +86,7 @@ void ConfigureCurlForGet(CURL* curl, const Url& url, const Config& config, std::
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &WriteBody);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &body);
     curl_easy_setopt(curl, CURLOPT_TCP_KEEPALIVE, 1L);
+    curl_easy_setopt(curl, CURLOPT_SSL_SESSIONID_CACHE, config.tls_session_cache_enabled ? 1L : 0L);
     curl_easy_setopt(curl, CURLOPT_MAXCONNECTS, static_cast<long>(config.max_connections));
     curl_easy_setopt(curl, CURLOPT_FORBID_REUSE, config.reuse_discovery_connections ? 0L : 1L);
     curl_easy_setopt(curl, CURLOPT_FRESH_CONNECT, config.reuse_discovery_connections ? 0L : 1L);
@@ -76,6 +111,13 @@ void ConfigureCurlForGet(CURL* curl, const Url& url, const Config& config, std::
     if (!config.client_private_key_file.empty()) {
         curl_easy_setopt(curl, CURLOPT_SSLKEY, config.client_private_key_file.c_str());
     }
+
+#if SCYLLADB_ALTERNATOR_CLIENT_CPP_HAS_OPENSSL
+    if (CurlUsesOpenSslBackend()) {
+        curl_easy_setopt(curl, CURLOPT_SSL_CTX_FUNCTION, &ConfigureSslContext);
+        curl_easy_setopt(curl, CURLOPT_SSL_CTX_DATA, &config);
+    }
+#endif
 }
 
 HttpResponse PerformCurlGet(CURL* curl, const Url& url, const Config& config) {

--- a/tests/live_nodes_test.cpp
+++ b/tests/live_nodes_test.cpp
@@ -397,3 +397,14 @@ TEST(AlternatorLiveNodes, BackgroundRefreshUsesActivePeriodOnlyAfterActivity) {
     EXPECT_GT(requests.load(), 0);
     EXPECT_EQ(Hosts(nodes.GetNodes()), std::vector<std::string>({"node2.local"}));
 }
+
+TEST(AlternatorLiveNodes, RejectsInvalidTlsSessionCacheConfig) {
+    Config cfg;
+    cfg.tls_session_cache_size = 0;
+
+    auto http = std::make_shared<FakeHttpClient>([](const Url&) {
+        return HttpResponse{200, "[]"};
+    });
+
+    EXPECT_THROW(AlternatorLiveNodes({"node1.local"}, cfg, http), std::invalid_argument);
+}


### PR DESCRIPTION
## Summary
- add TLS session cache enable, size, and timeout settings
- enable libcurl TLS session caching by default for HTTPS discovery
- apply cache size and timeout for OpenSSL-backed libcurl builds
- document TLS session cache defaults and add config validation coverage

## Testing
- `make check`
- `make test-unit`

Fixes #14