### PR TITLE
Cover BatchWriteItem affinity voting stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # C++ Alternator client
 
-This repository provides a C++ analogue of `alternator-client-golang` for ScyllaDB Alternator deployments that expose the DynamoDB API across multiple nodes.
+This repository provides a C++ Alternator client for ScyllaDB deployments that expose the DynamoDB API across multiple nodes.
 
 The core library discovers Alternator nodes through `/localnodes`, keeps a live node set, supports rack/datacenter routing scopes with fallbacks, tracks active/quarantined/down node state, and feeds query plans from one candidate list. Quarantine sampling is handled by the live-node source before a query plan is built. An optional AWS SDK for C++ adapter creates a DynamoDB client with a dynamic endpoint provider.
 
@@ -59,7 +59,7 @@ int main() {
 
 The AWS adapter uses the SDK's per-client `DynamoDBEndpointProviderBase` hook by default. AWS SDK for C++ resolves that endpoint once for a retried operation, so `DynamoDBHelper::ApplyToSDKOptions()` can also install a process-wide HTTP client factory before `Aws::InitAPI()`. That factory delegates to the SDK HTTP client and rotates only requests already aimed at the helper's Alternator endpoints.
 
-The HTTP client factory runs after request signing. This is the closest public AWS SDK for C++ hook to Go SDK v2's post-retry, pre-signing middleware, but it means applications that depend on strict SigV4 host validation should prefer endpoint-provider routing or implement their own SDK wrapper. Automatic middleware features such as transparent header optimization and request-content-based endpoint rewriting are not available in the same form. The core library does provide the deterministic key-route affinity primitives used by the Go client, and `DynamoDBHelper` exposes them for applications that integrate request-specific routing in their own AWS SDK wrapper.
+The HTTP client factory runs after request signing. This is the closest public AWS SDK for C++ hook for retry-aware endpoint rewriting, but it means applications that depend on strict SigV4 host validation should prefer endpoint-provider routing or implement their own SDK wrapper. Automatic middleware features such as transparent header optimization and request-content-based endpoint rewriting are not available in the same form. The core library does provide deterministic key-route affinity primitives, and `DynamoDBHelper` exposes them for applications that integrate request-specific routing in their own AWS SDK wrapper.
 
 ### DynamoDB HTTP Connections
 
@@ -147,8 +147,8 @@ cfg.tls_session_cache_size = 1024;
 cfg.tls_session_timeout = std::chrono::hours(24);
 ```
 
-The endpoint provider itself chooses nodes, but AWS SDK for C++ does not expose a public per-attempt hook equivalent to
-the Go SDK v2 middleware used by `alternator-client-golang`.
+The endpoint provider itself chooses nodes, but AWS SDK for C++ does not expose a public per-attempt hook before request
+signing.
 
 For individual requests, the helper can attach AWS SDK retry hooks that report the signed endpoint when the SDK retries:
 
@@ -160,7 +160,7 @@ auto outcome = ddb->PutItem(request);
 
 ### Key Route Affinity
 
-Key-route affinity makes write operations with the same partition key prefer the same coordinator. This can improve read-before-write paths such as conditional writes. The C++ core mirrors the Go client's Murmur3/AttributeValue hashing and seeded query-plan selection:
+Key-route affinity makes write operations with the same partition key prefer the same coordinator. This can improve read-before-write paths such as conditional writes. The C++ core uses deterministic Murmur3/AttributeValue hashing and seeded query-plan selection:
 
 ```cpp
 using namespace scylladb::alternator;
@@ -178,7 +178,7 @@ auto plan = helper.NewPartitionKeyQueryPlan(
 auto preferred = plan.Next();
 ```
 
-For `BatchWriteItem`-style operations, pass the put/delete candidates and the helper will vote for preferred nodes using the same deterministic ordering as the Go SDK v2 helper:
+For `BatchWriteItem`-style operations, pass the put/delete candidates and the helper will vote for preferred nodes. Voted nodes are tried first by descending vote count, with deterministic node-order tie breaking:
 
 ```cpp
 auto batch_plan = helper.NewBatchWriteQueryPlan({
@@ -197,10 +197,10 @@ auto batch_plan = helper.NewBatchWriteQueryPlan({
 - TLS session cache enable/disable, cache size, and timeout configuration for HTTPS discovery.
 - Persistent AWS SDK DynamoDB HTTP connection pooling via `max_connections`.
 - Active, quarantined, and down node pools with rigid observation-based transitions.
-- Round-robin `NextNode()` and flat per-request query plans, including Go-compatible seeded plans for affinity callers.
+- Round-robin `NextNode()` and flat per-request query plans, including deterministic seeded plans for affinity callers.
 - Key-route affinity helpers for single-write partition keys and batch-write preferred-node voting.
 - TLS verification toggle, CA file, client certificate/key file, and HTTP timeouts for libcurl discovery.
-- Cross-language Murmur3/AttributeValue hashing helpers for string, number, and binary partition key values.
+- Murmur3/AttributeValue hashing helpers for string, number, and binary partition key values.
 - Optional AWS SDK for C++ DynamoDB helper and endpoint provider.
 
 ## Targets

--- a/tests/key_route_affinity_test.cpp
+++ b/tests/key_route_affinity_test.cpp
@@ -119,7 +119,7 @@ TEST(QueryPlan, PreferredNodesComeFirstThenSortedRemaining) {
     EXPECT_EQ(hosts, want);
 }
 
-TEST(KeyRouteAffinity, ReadBeforeWriteMatchesGoHeuristics) {
+TEST(KeyRouteAffinity, ReadBeforeWriteMatchesConditionalWriteHeuristics) {
     WriteOperationOptions no_options;
     EXPECT_FALSE(ShouldUseKeyRouteAffinity(KeyRouteAffinityMode::ReadBeforeWrite,
                                            WriteOperationKind::PutItem,
@@ -217,6 +217,35 @@ TEST(KeyRouteAffinity, BatchWriteVotingSelectsPreferredNode) {
     auto rest = SortedHostsExcept({target.host});
     want.insert(want.end(), rest.begin(), rest.end());
     EXPECT_EQ(hosts, want);
+}
+
+TEST(KeyRouteAffinity, BatchWriteVotingIsStableForEquivalentBatches) {
+    const auto sorted_nodes = BatchWriteSortedTestNodes();
+    const auto target = sorted_nodes[0];
+    const auto other = sorted_nodes[1];
+    const auto target_keys = StringKeysForNode(target, 2);
+    const auto other_key = StringKeysForNode(other, 1)[0];
+
+    StaticNodes nodes(BatchWriteTestNodes());
+    auto metadata = Metadata({{"audit", "id"}, {"orders", "id"}});
+    const std::vector<BatchWriteOperation> first{
+        BatchWriteOperation::Put("orders", ItemWithId(target_keys[0], "orders-payload")),
+        BatchWriteOperation::Delete("orders", KeyWithId(other_key)),
+        BatchWriteOperation::Put("audit", ItemWithId(target_keys[1], "audit-payload")),
+    };
+    const std::vector<BatchWriteOperation> second{
+        BatchWriteOperation::Put("audit", ItemWithId(target_keys[1], "changed-audit-payload")),
+        BatchWriteOperation::Delete("orders", KeyWithId(other_key)),
+        BatchWriteOperation::Put("orders", ItemWithId(target_keys[0], "changed-orders-payload")),
+    };
+
+    auto first_preferred = SelectBatchWritePreferredNodes(nodes, first, metadata);
+    auto second_preferred = SelectBatchWritePreferredNodes(nodes, second, metadata);
+
+    const std::vector<Url> want{target, other};
+    EXPECT_EQ(first_preferred, want);
+    EXPECT_EQ(second_preferred, want);
+    EXPECT_EQ(second_preferred, first_preferred);
 }
 
 TEST(KeyRouteAffinity, BatchWriteVotingKeepsQuarantineOutOfAffinityDomain) {


### PR DESCRIPTION
Jira task: https://scylladb.atlassian.net/browse/DRIVER-655
Jira epic: https://scylladb.atlassian.net/browse/DRIVER-653
GitHub issue: https://github.com/scylladb/alternator-client-cpp/issues/32

## Summary
- Make BatchWriteItem candidates vote for preferred coordinators.
- Keep all voted coordinators first, ordered by descending vote count with deterministic node-order tie breaking.
- Add equivalent-batch coverage for reordered put/delete candidates and changed non-key payload values.

## Testing
- `make test`

Closes #32