### PR TITLE
Fix cluster-wide seed discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,19 @@ nodes.UpdateLiveNodes();
 auto next = nodes.NextNode();
 ```
 
+For cluster-wide routing, the client queries bare `/localnodes` on every configured initial node and merges
+the returned node lists. Some ScyllaDB versions return only the contacted node's datacenter from
+`/localnodes`, even with cluster scope. In multi-datacenter deployments, configure at least one working
+initial node from every datacenter that should receive traffic:
+
+```cpp
+AlternatorLiveNodes nodes({
+    "dc1-node.example.com",
+    "dc2-node.example.com",
+    "dc3-node.example.com",
+}, cfg);
+```
+
 ## AWS SDK for C++ Usage
 
 ```cpp
@@ -191,7 +204,7 @@ auto batch_plan = helper.NewBatchWriteQueryPlan({
 
 - `/localnodes` discovery with cluster, datacenter, and rack scopes.
 - Scope fallback chains such as rack -> datacenter -> cluster.
-- Cluster scope merge across seed nodes.
+- Cluster scope merge across configured initial nodes.
 - Active and idle `/localnodes` refresh cadence.
 - Reused libcurl discovery HTTP connections with an opt-out switch.
 - TLS session cache enable/disable, cache size, and timeout configuration for HTTPS discovery.

--- a/include/scylladb/alternator/live_nodes.h
+++ b/include/scylladb/alternator/live_nodes.h
@@ -49,6 +49,7 @@ public:
 private:
     [[nodiscard]] std::vector<Url> FetchLiveNodes();
     [[nodiscard]] std::vector<Url> GetNodesForScope(const RoutingScope& scope);
+    [[nodiscard]] std::vector<Url> GetDiscoveryNodesForScope(const RoutingScope& scope) const;
     [[nodiscard]] std::vector<Url> GetNodesFromEndpoint(const Url& endpoint) const;
     [[nodiscard]] Url NextKnownNode();
     [[nodiscard]] bool ShouldTryQuarantinedNode(bool active_nodes_empty) const;

--- a/src/live_nodes.cpp
+++ b/src/live_nodes.cpp
@@ -373,7 +373,7 @@ std::vector<Url> AlternatorLiveNodes::FetchLiveNodes() {
 
 std::vector<Url> AlternatorLiveNodes::GetNodesForScope(const RoutingScope& scope) {
     const bool cluster_scope = scope.IsCluster();
-    QueryPlan plan(GetQueryPlanNodes());
+    QueryPlan plan(GetDiscoveryNodesForScope(scope));
     std::vector<Url> discovered;
     std::exception_ptr last_error;
 
@@ -409,6 +409,13 @@ std::vector<Url> AlternatorLiveNodes::GetNodesForScope(const RoutingScope& scope
         std::rethrow_exception(last_error);
     }
     return {};
+}
+
+std::vector<Url> AlternatorLiveNodes::GetDiscoveryNodesForScope(const RoutingScope& scope) const {
+    if (scope.IsCluster()) {
+        return initial_nodes_;
+    }
+    return GetQueryPlanNodes();
 }
 
 std::vector<Url> AlternatorLiveNodes::GetNodesFromEndpoint(const Url& endpoint) const {

--- a/tests/live_nodes_test.cpp
+++ b/tests/live_nodes_test.cpp
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <atomic>
 #include <cstdint>
 #include <functional>
@@ -102,6 +103,41 @@ TEST(AlternatorLiveNodes, ClusterScopeMergesSeedNodes) {
               }));
     EXPECT_GT(dc1_requests.load(), 0);
     EXPECT_GT(dc2_requests.load(), 0);
+}
+
+TEST(AlternatorLiveNodes, ClusterScopeRefreshUsesConfiguredSeedNodes) {
+    Config cfg;
+    cfg.routing_scope = NewClusterScope();
+    cfg.nodes_list_update_period = std::chrono::milliseconds{0};
+
+    std::vector<std::string> requested_hosts;
+    auto http = std::make_shared<FakeHttpClient>([&](const Url& url) {
+        EXPECT_EQ(url.path, "/localnodes");
+        EXPECT_EQ(url.query, "");
+        requested_hosts.push_back(url.host);
+        if (url.host == "seed-dc1.local") {
+            return HttpResponse{200, "[\"dc1-node1.local\",\"dc1-node2.local\"]"};
+        }
+        if (url.host == "seed-dc2.local") {
+            return HttpResponse{200, "[\"dc2-node1.local\",\"dc2-node2.local\"]"};
+        }
+        return HttpResponse{500, ""};
+    });
+
+    AlternatorLiveNodes nodes({"seed-dc1.local", "seed-dc2.local"}, cfg, http);
+    nodes.UpdateLiveNodes();
+    nodes.UpdateLiveNodes();
+
+    EXPECT_EQ(Hosts(nodes.GetNodes()),
+              std::vector<std::string>({
+                  "dc1-node1.local",
+                  "dc1-node2.local",
+                  "dc2-node1.local",
+                  "dc2-node2.local",
+              }));
+    EXPECT_EQ(requested_hosts.size(), 4U);
+    EXPECT_EQ(std::count(requested_hosts.begin(), requested_hosts.end(), "seed-dc1.local"), 2);
+    EXPECT_EQ(std::count(requested_hosts.begin(), requested_hosts.end(), "seed-dc2.local"), 2);
 }
 
 TEST(AlternatorLiveNodes, CheckIfRackAndDatacenterSetCorrectlyRejectsWrongDatacenter) {


### PR DESCRIPTION
Closes #31

## Summary
- Use configured initial nodes as the discovery plan for cluster-wide `/localnodes` refreshes.
- Keep datacenter and rack scoped discovery on the existing active-node query plan.
- Document the multi-datacenter requirement to configure at least one initial node per datacenter.

## Verification
- cmake --build build --parallel
- cmake --build build-check --parallel
- ctest --test-dir build --output-on-failure -E Integration
- make test-integration