### PR TITLE
Add partition key autodiscovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,6 @@ using namespace scylladb::alternator;
 
 Config cfg;
 cfg.key_route_affinity.mode = KeyRouteAffinityMode::AnyWrite;
-cfg.key_route_affinity.partition_key_by_table = {{"orders", "id"}};
 
 scylladb::alternator::aws::DynamoDBHelper helper({"node1.example.com", "node2.example.com"}, cfg);
 
@@ -189,6 +188,22 @@ auto plan = helper.NewPartitionKeyQueryPlan(
     "orders");
 
 auto preferred = plan.Next();
+```
+
+The AWS helper can discover missing table partition-key names automatically. When an affinity plan needs metadata that is
+not cached yet, the helper starts one background `DescribeTable` lookup for that table and returns a normal non-affinity
+query plan for the current request. Later requests use the discovered HASH key name once the lookup completes. Configure
+`cfg.key_route_affinity.partition_key_by_table` when you already know the table metadata and do not want to wait for
+discovery:
+
+```cpp
+cfg.key_route_affinity.partition_key_by_table = {{"orders", "id"}};
+```
+
+You can also refresh one table explicitly during startup:
+
+```cpp
+(void)helper.UpdatePartitionKeyName("orders");
 ```
 
 For `BatchWriteItem`-style operations, pass the put/delete candidates and the helper will vote for preferred nodes. Voted nodes are tried first by descending vote count, with deterministic node-order tie breaking:

--- a/include/scylladb/alternator/aws/dynamodb_helper.h
+++ b/include/scylladb/alternator/aws/dynamodb_helper.h
@@ -2,7 +2,9 @@
 
 #include <memory>
 #include <mutex>
+#include <set>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include <aws/core/AmazonWebServiceRequest.h>
@@ -96,6 +98,9 @@ public:
                    std::shared_ptr<HttpClient> discovery_http_client = nullptr);
     ~DynamoDBHelper();
 
+    DynamoDBHelper(const DynamoDBHelper&) = delete;
+    DynamoDBHelper& operator=(const DynamoDBHelper&) = delete;
+
     [[nodiscard]] std::shared_ptr<Aws::DynamoDB::DynamoDBClient> NewDynamoDB() const;
     [[nodiscard]] Aws::DynamoDB::DynamoDBClientConfiguration NewClientConfiguration() const;
     [[nodiscard]] std::shared_ptr<AlternatorEndpointProvider> NewEndpointProvider() const;
@@ -109,6 +114,7 @@ public:
     void ReportNodeResult(const Url& node, NodeHealthObservation observation);
     void SetPartitionKeyName(const std::string& table_name, std::string partition_key_name);
     [[nodiscard]] std::string GetPartitionKeyName(const std::string& table_name) const;
+    [[nodiscard]] bool UpdatePartitionKeyName(const std::string& table_name) const;
     [[nodiscard]] bool ShouldUseKeyRouteAffinityForWrite(WriteOperationKind kind,
                                                          const WriteOperationOptions& options) const;
     [[nodiscard]] QueryPlan NewPartitionKeyQueryPlan(const AttributeMap& values,
@@ -122,9 +128,22 @@ public:
     [[nodiscard]] bool CheckIfRackDatacenterFeatureIsSupported();
 
 private:
+    struct PartitionKeyDiscoveryState {
+        mutable std::mutex mutex;
+        std::set<std::string> in_progress;
+        std::vector<std::thread> workers;
+    };
+
+    void TriggerPartitionKeyDiscovery(const std::string& table_name) const;
+    void TriggerPartitionKeyDiscoveryForMissingMetadata(const std::vector<BatchWriteOperation>& operations) const;
+    void WaitForPartitionKeyDiscovery() const;
+    [[nodiscard]] std::string DiscoverPartitionKeyName(const std::string& table_name) const;
+    [[nodiscard]] QueryPlan DefaultQueryPlan() const;
+
     std::shared_ptr<AlternatorLiveNodes> nodes_;
     Config config_;
-    PartitionKeyMetadata partition_keys_;
+    std::shared_ptr<PartitionKeyMetadata> partition_keys_;
+    std::shared_ptr<PartitionKeyDiscoveryState> partition_key_discovery_;
 };
 
 } // namespace scylladb::alternator::aws

--- a/src/aws_dynamodb_helper.cpp
+++ b/src/aws_dynamodb_helper.cpp
@@ -9,9 +9,13 @@
 #include <aws/core/http/HttpTypes.h>
 #include <aws/core/http/curl/CurlHttpClient.h>
 #include <aws/core/http/standard/StandardHttpRequest.h>
+#include <aws/core/utils/logging/LogMacros.h>
+#include <aws/dynamodb/model/DescribeTableRequest.h>
+#include <aws/dynamodb/model/KeySchemaElement.h>
 
 #include <algorithm>
 #include <cstdint>
+#include <set>
 #include <stdexcept>
 #include <utility>
 
@@ -298,11 +302,13 @@ DynamoDBHelper::DynamoDBHelper(std::vector<std::string> initial_nodes,
                                                    config,
                                                    std::move(discovery_http_client)))
     , config_(std::move(config))
-    , partition_keys_(config_.key_route_affinity.partition_key_by_table) {
+    , partition_keys_(std::make_shared<PartitionKeyMetadata>(config_.key_route_affinity.partition_key_by_table))
+    , partition_key_discovery_(std::make_shared<PartitionKeyDiscoveryState>()) {
     nodes_->Start();
 }
 
 DynamoDBHelper::~DynamoDBHelper() {
+    WaitForPartitionKeyDiscovery();
     Stop();
 }
 
@@ -386,11 +392,23 @@ void DynamoDBHelper::ReportNodeResult(const Url& node, NodeHealthObservation obs
 }
 
 void DynamoDBHelper::SetPartitionKeyName(const std::string& table_name, std::string partition_key_name) {
-    partition_keys_.SetPartitionKeyName(table_name, std::move(partition_key_name));
+    partition_keys_->SetPartitionKeyName(table_name, std::move(partition_key_name));
 }
 
 std::string DynamoDBHelper::GetPartitionKeyName(const std::string& table_name) const {
-    return partition_keys_.GetPartitionKeyName(table_name);
+    return partition_keys_->GetPartitionKeyName(table_name);
+}
+
+bool DynamoDBHelper::UpdatePartitionKeyName(const std::string& table_name) const {
+    if (table_name.empty()) {
+        return false;
+    }
+    const auto key_name = DiscoverPartitionKeyName(table_name);
+    if (key_name.empty()) {
+        return false;
+    }
+    partition_keys_->SetPartitionKeyName(table_name, key_name);
+    return true;
 }
 
 bool DynamoDBHelper::ShouldUseKeyRouteAffinityForWrite(WriteOperationKind kind,
@@ -400,11 +418,25 @@ bool DynamoDBHelper::ShouldUseKeyRouteAffinityForWrite(WriteOperationKind kind,
 
 QueryPlan DynamoDBHelper::NewPartitionKeyQueryPlan(const AttributeMap& values,
                                                    const std::string& table_name) const {
-    return QueryPlanForPartitionKey(*nodes_, values, table_name, partition_keys_);
+    if (partition_keys_->GetPartitionKeyName(table_name).empty()) {
+        TriggerPartitionKeyDiscovery(table_name);
+        return DefaultQueryPlan();
+    }
+
+    try {
+        return QueryPlanForPartitionKey(*nodes_, values, table_name, *partition_keys_);
+    } catch (const std::invalid_argument&) {
+        return DefaultQueryPlan();
+    }
 }
 
 QueryPlan DynamoDBHelper::NewBatchWriteQueryPlan(const std::vector<BatchWriteOperation>& operations) const {
-    return QueryPlanForBatchWrite(*nodes_, operations, partition_keys_);
+    TriggerPartitionKeyDiscoveryForMissingMetadata(operations);
+    try {
+        return QueryPlanForBatchWrite(*nodes_, operations, *partition_keys_);
+    } catch (const std::invalid_argument&) {
+        return DefaultQueryPlan();
+    }
 }
 
 void DynamoDBHelper::CheckIfRackAndDatacenterSetCorrectly() {
@@ -413,6 +445,98 @@ void DynamoDBHelper::CheckIfRackAndDatacenterSetCorrectly() {
 
 bool DynamoDBHelper::CheckIfRackDatacenterFeatureIsSupported() {
     return nodes_->CheckIfRackDatacenterFeatureIsSupported();
+}
+
+void DynamoDBHelper::TriggerPartitionKeyDiscovery(const std::string& table_name) const {
+    if (table_name.empty() || !partition_keys_->GetPartitionKeyName(table_name).empty()) {
+        return;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(partition_key_discovery_->mutex);
+        if (!partition_key_discovery_->in_progress.insert(table_name).second) {
+            return;
+        }
+    }
+
+    try {
+        std::lock_guard<std::mutex> lock(partition_key_discovery_->mutex);
+        partition_key_discovery_->workers.emplace_back([this, table_name] {
+            try {
+                (void)UpdatePartitionKeyName(table_name);
+            } catch (const std::exception& error) {
+                AWS_LOGSTREAM_ERROR(
+                    kAllocationTag,
+                    "partition-key discovery failed for table " << table_name << ": " << error.what());
+            } catch (...) {
+                AWS_LOGSTREAM_ERROR(
+                    kAllocationTag,
+                    "partition-key discovery failed for table " << table_name << ": unknown error");
+            }
+
+            std::lock_guard<std::mutex> lock(partition_key_discovery_->mutex);
+            partition_key_discovery_->in_progress.erase(table_name);
+        });
+    } catch (...) {
+        std::lock_guard<std::mutex> lock(partition_key_discovery_->mutex);
+        partition_key_discovery_->in_progress.erase(table_name);
+    }
+}
+
+void DynamoDBHelper::TriggerPartitionKeyDiscoveryForMissingMetadata(
+    const std::vector<BatchWriteOperation>& operations) const {
+    std::set<std::string> missing_tables;
+    for (const auto& operation : operations) {
+        if (partition_keys_->GetPartitionKeyName(operation.table_name).empty()) {
+            missing_tables.insert(operation.table_name);
+        }
+    }
+    for (const auto& table_name : missing_tables) {
+        TriggerPartitionKeyDiscovery(table_name);
+    }
+}
+
+void DynamoDBHelper::WaitForPartitionKeyDiscovery() const {
+    std::vector<std::thread> workers;
+    {
+        std::lock_guard<std::mutex> lock(partition_key_discovery_->mutex);
+        workers.swap(partition_key_discovery_->workers);
+    }
+
+    for (auto& worker : workers) {
+        if (worker.joinable()) {
+            worker.join();
+        }
+    }
+}
+
+std::string DynamoDBHelper::DiscoverPartitionKeyName(const std::string& table_name) const {
+    auto client = NewDynamoDB();
+    Aws::DynamoDB::Model::DescribeTableRequest request;
+    request.SetTableName(Aws::String(table_name.c_str()));
+
+    const auto outcome = client->DescribeTable(request);
+    if (!outcome.IsSuccess()) {
+        AWS_LOGSTREAM_ERROR(
+            kAllocationTag,
+            "DescribeTable failed during partition-key discovery for table "
+                << table_name << ": " << outcome.GetError().GetMessage());
+        return {};
+    }
+
+    for (const auto& key_schema : outcome.GetResult().GetTable().GetKeySchema()) {
+        if (key_schema.GetKeyType() == Aws::DynamoDB::Model::KeyType::HASH) {
+            return std::string(key_schema.GetAttributeName().c_str());
+        }
+    }
+    AWS_LOGSTREAM_ERROR(
+        kAllocationTag,
+        "DescribeTable returned no HASH key during partition-key discovery for table " << table_name);
+    return {};
+}
+
+QueryPlan DynamoDBHelper::DefaultQueryPlan() const {
+    return QueryPlan::FromNodesSource(*nodes_);
 }
 
 } // namespace scylladb::alternator::aws

--- a/tests/aws_dynamodb_helper_test.cpp
+++ b/tests/aws_dynamodb_helper_test.cpp
@@ -13,6 +13,7 @@
 #include <gtest/gtest.h>
 
 #include <atomic>
+#include <chrono>
 #include <cctype>
 #include <cstring>
 #include <sstream>
@@ -133,6 +134,7 @@ struct SequencedHttpResponse {
     int status_code = 200;
     std::string reason = "OK";
     std::string body;
+    std::chrono::milliseconds delay{0};
 };
 
 class KeepAliveSequenceHttpServer {
@@ -282,6 +284,9 @@ private:
     }
 
     static void SendResponse(int client, const SequencedHttpResponse& response, bool keep_connection) {
+        if (response.delay > std::chrono::milliseconds::zero()) {
+            std::this_thread::sleep_for(response.delay);
+        }
         std::ostringstream text;
         text << "HTTP/1.1 " << response.status_code << " " << response.reason << "\r\n"
              << "Content-Type: application/x-amz-json-1.0\r\n"
@@ -314,6 +319,40 @@ std::string HostHeader(const std::string& request) {
         return {};
     }
     return request.substr(start, end - start);
+}
+
+std::string DescribeTableResponse(const std::string& table_name,
+                                  const std::string& partition_key_name) {
+    return R"({"Table":{"TableName":")" + table_name + R"(","KeySchema":[{"AttributeName":")" +
+           partition_key_name + R"(","KeyType":"HASH"},{"AttributeName":"sk","KeyType":"RANGE"}]}})";
+}
+
+bool WaitForPartitionKeyName(const aws::DynamoDBHelper& helper,
+                             const std::string& table_name,
+                             const std::string& partition_key_name) {
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (helper.GetPartitionKeyName(table_name) == partition_key_name) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    return false;
+}
+
+Config DiscoveryTestConfig(std::uint16_t port) {
+    Config cfg;
+    cfg.port = port;
+    cfg.scheme = "http";
+    cfg.aws_region = "us-east-1";
+    cfg.credentials = {"alternator", "secret"};
+    cfg.nodes_list_update_period = std::chrono::milliseconds{0};
+    cfg.idle_nodes_list_update_period = std::chrono::milliseconds{0};
+    cfg.node_health.down_node_probe_period = std::chrono::milliseconds{0};
+    cfg.http_client_timeout = std::chrono::milliseconds{2000};
+    cfg.connect_timeout = std::chrono::milliseconds{1000};
+    cfg.key_route_affinity.mode = KeyRouteAffinityMode::AnyWrite;
+    return cfg;
 }
 
 } // namespace
@@ -390,6 +429,93 @@ TEST(AwsDynamoDBHelper, DefaultsToConfiguredSdkConnectionPoolLimit) {
     auto client_config = helper.NewClientConfiguration();
     EXPECT_EQ(client_config.maxConnections, cfg.max_connections);
     EXPECT_EQ(client_config.maxConnections, 100U);
+}
+
+TEST(AwsDynamoDBHelper, AutoDiscoversPartitionKeyNameWithDescribeTable) {
+    KeepAliveSequenceHttpServer server({
+        {200, "OK", DescribeTableResponse("orders", "id")},
+    });
+
+    Aws::SDKOptions sdk_options;
+    AwsApiGuard api(sdk_options);
+
+    auto cfg = DiscoveryTestConfig(server.Port());
+    aws::DynamoDBHelper helper({"127.0.0.1"}, cfg);
+
+    EXPECT_EQ(helper.GetPartitionKeyName("orders"), "");
+
+    auto plan = helper.NewPartitionKeyQueryPlan({{"id", AttributeValue::String("order-123")}}, "orders");
+    EXPECT_FALSE(plan.Next().Empty());
+
+    EXPECT_TRUE(WaitForPartitionKeyName(helper, "orders", "id"));
+    server.Wait();
+
+    ASSERT_EQ(server.Requests().size(), 1U);
+    EXPECT_NE(server.Requests()[0].find("DescribeTable"), std::string::npos);
+}
+
+TEST(AwsDynamoDBHelper, UpdatesPartitionKeyNameOnDemand) {
+    KeepAliveSequenceHttpServer server({
+        {200, "OK", DescribeTableResponse("orders", "id")},
+    });
+
+    Aws::SDKOptions sdk_options;
+    AwsApiGuard api(sdk_options);
+
+    auto cfg = DiscoveryTestConfig(server.Port());
+    aws::DynamoDBHelper helper({"127.0.0.1"}, cfg);
+
+    EXPECT_TRUE(helper.UpdatePartitionKeyName("orders"));
+    EXPECT_EQ(helper.GetPartitionKeyName("orders"), "id");
+    server.Wait();
+
+    ASSERT_EQ(server.Requests().size(), 1U);
+    EXPECT_NE(server.Requests()[0].find("DescribeTable"), std::string::npos);
+}
+
+TEST(AwsDynamoDBHelper, SuppressesDuplicatePartitionKeyDiscoveryForTable) {
+    KeepAliveSequenceHttpServer server({
+        {200, "OK", DescribeTableResponse("orders", "id"), std::chrono::milliseconds{200}},
+    });
+
+    Aws::SDKOptions sdk_options;
+    AwsApiGuard api(sdk_options);
+
+    auto cfg = DiscoveryTestConfig(server.Port());
+    aws::DynamoDBHelper helper({"127.0.0.1"}, cfg);
+
+    for (int i = 0; i < 3; ++i) {
+        auto plan = helper.NewPartitionKeyQueryPlan({{"id", AttributeValue::String("order-123")}}, "orders");
+        EXPECT_FALSE(plan.Next().Empty());
+    }
+
+    EXPECT_TRUE(WaitForPartitionKeyName(helper, "orders", "id"));
+    server.Wait();
+
+    EXPECT_EQ(server.Requests().size(), 1U);
+}
+
+TEST(AwsDynamoDBHelper, BatchWriteTriggersPartitionKeyDiscovery) {
+    KeepAliveSequenceHttpServer server({
+        {200, "OK", DescribeTableResponse("orders", "id")},
+    });
+
+    Aws::SDKOptions sdk_options;
+    AwsApiGuard api(sdk_options);
+
+    auto cfg = DiscoveryTestConfig(server.Port());
+    aws::DynamoDBHelper helper({"127.0.0.1"}, cfg);
+
+    auto plan = helper.NewBatchWriteQueryPlan({
+        BatchWriteOperation::Put("orders", {{"id", AttributeValue::String("order-123")}}),
+    });
+    EXPECT_FALSE(plan.Next().Empty());
+
+    EXPECT_TRUE(WaitForPartitionKeyName(helper, "orders", "id"));
+    server.Wait();
+
+    ASSERT_EQ(server.Requests().size(), 1U);
+    EXPECT_NE(server.Requests()[0].find("DescribeTable"), std::string::npos);
 }
 
 TEST(AwsDynamoDBHelper, HttpClientFactoryRotatesNodesAcrossRetries) {


### PR DESCRIPTION
## Summary

- add request-triggered background `DescribeTable` discovery for missing key-route-affinity partition-key metadata
- deduplicate concurrent lookups per table and cache discovered HASH key names
- make helper affinity plans fall back to normal routing until metadata is available
- document automatic discovery and add AWS-helper tests for discovery, duplicate suppression, and batch-write triggering

Closes #42.

## Tests

- `make test`

Note: local CMake did not find AWSSDK, so the AWS adapter tests were not built locally; CI with AWSSDK should compile/run the new AWS-helper coverage.