### PR TITLE
Retry partition key discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,14 @@ You can also refresh one table explicitly during startup:
 (void)helper.UpdatePartitionKeyName("orders");
 ```
 
+Discovery retries `DescribeTable` a few times with exponential backoff to tolerate transient metadata
+unavailability, such as writes immediately after `CreateTable`:
+
+```cpp
+cfg.key_route_affinity.partition_key_discovery_attempts = 3;
+cfg.key_route_affinity.partition_key_discovery_initial_backoff = std::chrono::milliseconds{100};
+```
+
 For `BatchWriteItem`-style operations, pass the put/delete candidates and the helper will vote for preferred nodes. Voted nodes are tried first by descending vote count, with deterministic node-order tie breaking:
 
 ```cpp

--- a/include/scylladb/alternator/key_route_affinity.h
+++ b/include/scylladb/alternator/key_route_affinity.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <cstdint>
 #include <map>
 #include <mutex>
@@ -21,6 +22,8 @@ enum class KeyRouteAffinityMode {
 struct KeyRouteAffinityConfig {
     KeyRouteAffinityMode mode = KeyRouteAffinityMode::None;
     std::map<std::string, std::string> partition_key_by_table;
+    std::uint32_t partition_key_discovery_attempts = 3;
+    std::chrono::milliseconds partition_key_discovery_initial_backoff{100};
 };
 
 class PartitionKeyMetadata {

--- a/src/aws_dynamodb_helper.cpp
+++ b/src/aws_dynamodb_helper.cpp
@@ -14,9 +14,11 @@
 #include <aws/dynamodb/model/KeySchemaElement.h>
 
 #include <algorithm>
+#include <chrono>
 #include <cstdint>
 #include <set>
 #include <stdexcept>
+#include <thread>
 #include <utility>
 
 namespace scylladb::alternator::aws {
@@ -403,12 +405,23 @@ bool DynamoDBHelper::UpdatePartitionKeyName(const std::string& table_name) const
     if (table_name.empty()) {
         return false;
     }
-    const auto key_name = DiscoverPartitionKeyName(table_name);
-    if (key_name.empty()) {
-        return false;
+
+    auto backoff = config_.key_route_affinity.partition_key_discovery_initial_backoff;
+    for (std::uint32_t attempt = 1; attempt <= config_.key_route_affinity.partition_key_discovery_attempts; ++attempt) {
+        const auto key_name = DiscoverPartitionKeyName(table_name);
+        if (!key_name.empty()) {
+            partition_keys_->SetPartitionKeyName(table_name, key_name);
+            return true;
+        }
+        if (attempt == config_.key_route_affinity.partition_key_discovery_attempts) {
+            break;
+        }
+        if (backoff > std::chrono::milliseconds::zero()) {
+            std::this_thread::sleep_for(backoff);
+            backoff *= 2;
+        }
     }
-    partition_keys_->SetPartitionKeyName(table_name, key_name);
-    return true;
+    return false;
 }
 
 bool DynamoDBHelper::ShouldUseKeyRouteAffinityForWrite(WriteOperationKind kind,

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -17,6 +17,12 @@ void ValidateConfig(const Config& config) {
     if (config.max_connections == 0) {
         throw std::invalid_argument("max_connections must be > 0");
     }
+    if (config.key_route_affinity.partition_key_discovery_attempts == 0) {
+        throw std::invalid_argument("partition_key_discovery_attempts must be > 0");
+    }
+    if (config.key_route_affinity.partition_key_discovery_initial_backoff < std::chrono::milliseconds::zero()) {
+        throw std::invalid_argument("partition_key_discovery_initial_backoff must be >= 0");
+    }
     if (config.tls_session_cache_enabled) {
         if (config.tls_session_cache_size == 0) {
             throw std::invalid_argument("tls_session_cache_size must be > 0 when TLS session cache is enabled");

--- a/tests/aws_dynamodb_helper_test.cpp
+++ b/tests/aws_dynamodb_helper_test.cpp
@@ -327,6 +327,10 @@ std::string DescribeTableResponse(const std::string& table_name,
            partition_key_name + R"(","KeyType":"HASH"},{"AttributeName":"sk","KeyType":"RANGE"}]}})";
 }
 
+std::string ResourceNotFoundResponse() {
+    return R"({"__type":"com.amazonaws.dynamodb.v20120810#ResourceNotFoundException","message":"not ready"})";
+}
+
 bool WaitForPartitionKeyName(const aws::DynamoDBHelper& helper,
                              const std::string& table_name,
                              const std::string& partition_key_name) {
@@ -471,6 +475,29 @@ TEST(AwsDynamoDBHelper, UpdatesPartitionKeyNameOnDemand) {
 
     ASSERT_EQ(server.Requests().size(), 1U);
     EXPECT_NE(server.Requests()[0].find("DescribeTable"), std::string::npos);
+}
+
+TEST(AwsDynamoDBHelper, RetriesPartitionKeyDiscoveryAfterTransientFailure) {
+    KeepAliveSequenceHttpServer server({
+        {400, "Bad Request", ResourceNotFoundResponse()},
+        {200, "OK", DescribeTableResponse("orders", "id")},
+    });
+
+    Aws::SDKOptions sdk_options;
+    AwsApiGuard api(sdk_options);
+
+    auto cfg = DiscoveryTestConfig(server.Port());
+    cfg.key_route_affinity.partition_key_discovery_attempts = 2;
+    cfg.key_route_affinity.partition_key_discovery_initial_backoff = std::chrono::milliseconds{0};
+    aws::DynamoDBHelper helper({"127.0.0.1"}, cfg);
+
+    EXPECT_TRUE(helper.UpdatePartitionKeyName("orders"));
+    EXPECT_EQ(helper.GetPartitionKeyName("orders"), "id");
+    server.Wait();
+
+    ASSERT_EQ(server.Requests().size(), 2U);
+    EXPECT_NE(server.Requests()[0].find("DescribeTable"), std::string::npos);
+    EXPECT_NE(server.Requests()[1].find("DescribeTable"), std::string::npos);
 }
 
 TEST(AwsDynamoDBHelper, SuppressesDuplicatePartitionKeyDiscoveryForTable) {


### PR DESCRIPTION
## Summary

- add bounded `DescribeTable` retry attempts for partition-key discovery
- add exponential discovery backoff configuration
- validate retry configuration
- document retry knobs and add retry coverage for transient missing metadata

Closes #45.

## Tests

- `make test`

Note: local CMake does not find AWSSDK, so AWS adapter tests compile/run in CI.