### PR TITLE
Use project version in default User-Agent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,9 @@ add_library(alternator_client_cpp
 add_library(ScyllaDB::alternator_client_cpp ALIAS alternator_client_cpp)
 
 target_compile_features(alternator_client_cpp PUBLIC cxx_std_17)
+target_compile_definitions(alternator_client_cpp
+    PUBLIC
+        SCYLLADB_ALTERNATOR_CLIENT_CPP_VERSION="${PROJECT_VERSION}")
 target_include_directories(alternator_client_cpp
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -106,6 +109,7 @@ if(ALTERNATOR_CLIENT_CPP_BUILD_TESTS)
 
         set(ALTERNATOR_CLIENT_CPP_CORE_TEST_SOURCES
             tests/attribute_value_test.cpp
+            tests/config_test.cpp
             tests/header_optimization_test.cpp
             tests/http_client_test.cpp
             tests/key_route_affinity_test.cpp

--- a/include/scylladb/alternator/config.h
+++ b/include/scylladb/alternator/config.h
@@ -10,6 +10,10 @@
 #include <scylladb/alternator/node_health.h>
 #include <scylladb/alternator/routing_scope.h>
 
+#ifndef SCYLLADB_ALTERNATOR_CLIENT_CPP_VERSION
+#define SCYLLADB_ALTERNATOR_CLIENT_CPP_VERSION "devel"
+#endif
+
 namespace scylladb::alternator {
 
 struct Credentials {
@@ -88,7 +92,7 @@ struct Config {
     unsigned max_connections = 100;
     bool reuse_discovery_connections = true;
     std::vector<std::shared_ptr<HttpContentEncodingDecoder>> content_encoding_decoders;
-    std::string user_agent = "scylladb-alternator-client-cpp/devel";
+    std::string user_agent = "scylladb-alternator-client-cpp/" SCYLLADB_ALTERNATOR_CLIENT_CPP_VERSION;
     std::shared_ptr<HeaderOptimization> header_optimization;
 
     NodeHealthStoreConfig node_health;

--- a/tests/config_test.cpp
+++ b/tests/config_test.cpp
@@ -1,0 +1,24 @@
+#include <scylladb/alternator/config.h>
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+using namespace scylladb::alternator;
+
+TEST(Config, DefaultUserAgentUsesProjectVersion) {
+    const Config config;
+
+    EXPECT_EQ(
+        config.user_agent,
+        std::string("scylladb-alternator-client-cpp/") + SCYLLADB_ALTERNATOR_CLIENT_CPP_VERSION);
+    EXPECT_NE(config.user_agent, "scylladb-alternator-client-cpp/devel");
+}
+
+TEST(Config, UserAgentCanBeCleared) {
+    Config config;
+
+    config.user_agent.clear();
+
+    EXPECT_TRUE(config.user_agent.empty());
+}


### PR DESCRIPTION
## Summary
- publish the CMake project version as a public compile definition for consumers
- use that version in the default Config::user_agent, with a devel fallback when no version definition is available
- add config tests for the versioned default and empty-string override

Closes #52

## Tests
- make check
- make test-unit
- cmake --install build --prefix build/install && rg -n "SCYLLADB_ALTERNATOR_CLIENT_CPP_VERSION|INTERFACE_COMPILE_DEFINITIONS" build/install/lib/cmake/scylladb-alternator-client-cpp