### PR TITLE
DRIVER-671 Document aws_region config

### DIFF
--- a/include/scylladb/alternator/config.h
+++ b/include/scylladb/alternator/config.h
@@ -101,6 +101,11 @@ struct Config {
     std::uint16_t port = 8080;
     std::string scheme = "http";
     RoutingScopePtr routing_scope = NewClusterScope();
+    // The AWS SDK requires a non-empty region for client configuration,
+    // signing scope, and diagnostics. Alternator routing ignores this value,
+    // so the default is only a placeholder. Set it to the deployment or
+    // Scylla Cloud region when SDK logs, traces, or metrics should show a
+    // meaningful region.
     std::string aws_region = "default-alb-region";
     Credentials credentials;
 


### PR DESCRIPTION
Jira: https://scylladb.atlassian.net/browse/DRIVER-671

Closes #9

Summary:
- document the AWS SDK reason for Config::aws_region next to the public field
- clarify that Alternator routing ignores the region and the default is only a placeholder
- point users to set a deployment or Scylla Cloud region for meaningful SDK observability

Testing:
- make check